### PR TITLE
fix: headers payload

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -35,7 +35,10 @@ export async function serveCache(
   const payload = { body: null, headers: null }
   if (!rv.stop) {
     payload.body = await cache.get('body:' + key)
-    payload.headers = JSON.parse((await cache.get('header:' + key)).toString())
+    const headersBuffer = await cache.get('header:' + key)
+    if (headersBuffer) {
+      payload.headers = JSON.parse(headersBuffer.toString())
+    }
   }
   send(payload, res)
 


### PR DESCRIPTION
the cache.get result in hybrid-disk-cache can be `undefined` which is not handled for the headers payload in next-boost.

```
  async get(key: string, defaultValue?: Buffer): Promise<Buffer | undefined> {
```
https://github.com/rjyo/hybrid-disk-cache/blob/master/src/index.ts#L62

this PR checks the cache.get result and only overwrites the payload.headers if defined.

closes https://github.com/rjyo/next-boost/issues/49