### PR TITLE
Automatically set cache-control header for cached pages

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -69,6 +69,7 @@ const wrap: WrappedHandler = (cache, conf, renderer, next, metrics) => {
 
       const args = { path: req.url, headers: req.headers, method: req.method }
       const rv = await renderer.render(args)
+      if (ttl > 0 && rv.statusCode === 200) rv.headers['cache-control'] = `public, max-age=${ttl}, must-revalidate`
       // rv.body is a Buffer in JSON format: { type: 'Buffer', data: [...] }
       const body = Buffer.from(rv.body)
       // stale has been served

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -69,7 +69,9 @@ const wrap: WrappedHandler = (cache, conf, renderer, next, metrics) => {
 
       const args = { path: req.url, headers: req.headers, method: req.method }
       const rv = await renderer.render(args)
-      if (ttl > 0 && rv.statusCode === 200) rv.headers['cache-control'] = `public, max-age=${ttl}, must-revalidate`
+      if (ttl && rv.statusCode === 200 && conf.cacheControl) {
+        rv.headers['cache-control'] = conf.cacheControl(req, ttl)
+      }
       // rv.body is a Buffer in JSON format: { type: 'Buffer', data: [...] }
       const body = Buffer.from(rv.body)
       // stale has been served

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export type CacheAdapter = {
 
 export type URLCacheRuleResolver = (req: IncomingMessage) => number
 
+export type CacheControlBuilder = (req: IncomingMessage, ttl: number) => string
+
 export interface HandlerConfig {
   filename?: string // config file's path
   quiet?: boolean
@@ -29,6 +31,7 @@ export interface HandlerConfig {
   cacheAdapter?: CacheAdapter
   paramFilter?: ParamFilter
   cacheKey?: CacheKeyBuilder
+  cacheControl?: CacheControlBuilder
   metrics?: boolean
 }
 

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -28,6 +28,7 @@ describe('cached handler', () => {
       .get('/hello')
       .end((_, res) => {
         expect(res.text).toEqual('hello')
+        expect(res.header['cache-control']).toEqual('public, max-age=0.5, must-revalidate')
         done()
       })
   })
@@ -37,6 +38,7 @@ describe('cached handler', () => {
       .get('/hello')
       .end((_, res) => {
         expect(res.text).toEqual('hello')
+        expect(res.header['cache-control']).toEqual('public, max-age=0.5, must-revalidate')
         done()
       })
   })


### PR DESCRIPTION
This PR automatically sets the `Cache-Control` header to `public, max-age=<TTL>, must-revalidate` for pages that are served from cache with a TTL > 0.

I'm up for adding more customizability to this which could live on the `routes` level if this is something you would like. I'm also thinking about if the cache header should be `public, max-age=0, s-maxage=<TTL>, stale-while-revalidate` instead.

Closes https://github.com/next-boost/next-boost/issues/23