### PR TITLE
Use with middleware

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -104,7 +104,7 @@ export default async function CachedHandler(args: InitArgs, options?: HandlerCon
 
   const renderer = Renderer()
   await renderer.init(args)
-  const plain = await require(args.script).default(args)
+  const plain = await require(args.script).default(args.args)
 
   const metrics = new Metrics()
 

--- a/src/next/server.ts
+++ b/src/next/server.ts
@@ -16,7 +16,7 @@ const serve = async (argv: Argv) => {
   const grace = (argv['--grace'] as number) || 30000
 
   const script = require.resolve('./init')
-  const rendererArgs = { script, args: { dir, dev: false } }
+  const rendererArgs = { script, args: { dir, dev: false, hostname, port } }
   const cached = await CachedHandler(rendererArgs, { quiet })
 
   const server = new http.Server(cached.handler)


### PR DESCRIPTION
> Error: To use middleware you must provide a `hostname` and `port` to the Next.js Server